### PR TITLE
Fix line ending issue for Windows environments

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,7 @@
     "sourceType": "module"
   },
   "rules": {
+    "prettier/prettier": [ "error", { "endOfLine": "auto" } ],
     "@typescript-eslint/explicit-member-accessibility": 0,
     "@typescript-eslint/explicit-function-return-type": 0,
     "@typescript-eslint/no-parameter-properties": 0,


### PR DESCRIPTION
### Description:
This pull request resolves the issue of line-ending mismatches that occur when creating a new project on Windows-based systems. The error encountered is:

`Delete `␍` eslint/prettier/prettier`

This issue arises due to differences in how line endings are handled across operating systems (Windows uses `CRLF` while Unix-based systems use `LF`). When logging to any file, this mismatch causes ESLint/Prettier errors.

### Changes Made:


- Added the following line to the `.eslintrc` file:


`"prettier/prettier": ["error", { "endOfLine": "auto" }]`

-This change ensures that Prettier automatically handles line endings based on the user’s environment, preventing the `␍` error on Windows systems while maintaining compatibility with Unix-based systems.

![image](https://github.com/user-attachments/assets/cdf871e8-ddf3-499c-97b7-ba021c3f882b)